### PR TITLE
Changed the way the waveformRenderWorker is imported

### DIFF
--- a/src/renderer/waveformRenderer.ts
+++ b/src/renderer/waveformRenderer.ts
@@ -110,7 +110,11 @@ export class WaveformRenderer {
         reject();
       }
 
-      this.currentWorker = new Worker("./workers/waveformRenderWorker.ts");
+      // Worker was not being bundled when building.
+      // https://webpack.js.org/guides/web-workers/
+      // https://github.com/vitejs/vite/issues/4642
+      // @ts-ignore
+      this.currentWorker = new Worker(new URL("./workers/waveformRenderWorker.ts", import.meta.url));
       this.currentWorker.postMessage({ canvas: offscreen, audioData }, [offscreen])
       this.currentWorker.onmessage = ({ data }) => {
         this.drawImage(data);


### PR DESCRIPTION
I believe the reason waveformRenderWorker wasn't included in the production build was because of the way it was referenced in the project.

Should fix issue 32
https://github.com/Geoxor/amethyst/issues/32