### PR TITLE
Make the FPS indicator use the max value

### DIFF
--- a/src/renderer/components/TopBar.vue
+++ b/src/renderer/components/TopBar.vue
@@ -175,8 +175,8 @@ const refreshWindow = () => location.reload();
         <div 
           :class="[
             fps < 30 && 'text-rose-500',
-            fps >= 30 && fps < 155 && 'text-yellow-300',
-            fps >= (155*0.8) && 'text-green-500',
+            fps >= 30 && fps < max && 'text-yellow-300',
+            fps >= (max*0.8) && 'text-green-500',
           ]"
           class="font-aseprite"
         >


### PR DESCRIPTION
Instead of using the hardcoded value "155", we should use max value instead. Mostly intended for those who don't use 120hz+ displays.