### PR TITLE
make settings view scrollable (fix SettingsView)

### DIFF
--- a/src/renderer/views/Settings/SettingsView.vue
+++ b/src/renderer/views/Settings/SettingsView.vue
@@ -44,7 +44,7 @@ import { PaintBrushIcon, GeometryIcon, CircusRingOfFireIcon, PuzzleIcon, WaveIco
         @click="$router.push({ name: 'settings.integration' })"
       />
     </navigation-bar>
-    <div class="p-2 text-11px w-full h-full flex flex-col gap-2">
+    <div class="p-2 text-11px w-full h-full flex flex-col gap-2" style="overflow-y: auto !important">
       <router-view />
     </div>
   </div>


### PR DESCRIPTION
while otis was speedrunning most of the bugs, he saw that scroller on settings view is not availbale so i fixed it

bug screenshot:
https://cdn.discordapp.com/attachments/967797529708212244/1075450531356626984/image.png