### PR TITLE
Add the Command + , (comma) shortcut to open settings, common on Macs, enhancement #328

### DIFF
--- a/src/renderer/amethyst.ts
+++ b/src/renderer/amethyst.ts
@@ -13,6 +13,7 @@ import { flattenArray } from "./logic/math";
 import { Track } from "./logic/track";
 import { Directory } from "@capacitor/filesystem";
 import * as mm from "music-metadata-browser";
+import { router } from "./router";
 
 export type AmethystPlatforms = ReturnType<typeof amethyst.getCurrentPlatform>;
 
@@ -156,6 +157,11 @@ class AmethystBackend {
       !result.canceled && amethyst.player.queue.add(flattenArray(result.filePaths));
     });
   };
+
+  public openSettings = () => {
+    // not 100% sure if this is the way to go for routing this? but it works as expected for me at least!
+    router.push({ name: 'settings.appearance' });
+  }
 
   // TODO: get rid of this stupid logic and make it be part of when loading a track
   public async getMetadata(path: string) {

--- a/src/renderer/shortcuts.ts
+++ b/src/renderer/shortcuts.ts
@@ -8,6 +8,7 @@ export class Shortcuts {
   public isControlPressed = useKeyModifier("Control") as UseKeyModifierReturn<boolean>;
   public isShiftPressed = useKeyModifier("Shift") as UseKeyModifierReturn<boolean>;
   public isAltPressed = useKeyModifier("Alt") as UseKeyModifierReturn<boolean>;
+  public isMacCommandPressed = useKeyModifier("Meta") as UseKeyModifierReturn<boolean>;
 
   // TODO: somehow link this logic to each function in the components so they render automatically in dropdown menus
   public DEFAULT_BINDINGS: ShortcutBindings = {
@@ -28,6 +29,7 @@ export class Shortcuts {
     "interface.zoom.in": [["+"], () => this.isControlPressed.value && amethyst.zoom("in")],
     "interface.zoom.out": [["-"], () => this.isControlPressed.value && amethyst.zoom("out")],
     "interface.zoom.reset": [["0"], () => this.isControlPressed.value && amethyst.zoom("reset")],
+    "interface.settings": [[","], () => this.isMacCommandPressed.value && amethyst.openSettings()],
   };
 
   public bindings = this.DEFAULT_BINDINGS;


### PR DESCRIPTION
Uses `useKeyModifier("Meta")` to detect the Command key (https://vuejs.org/guide/essentials/event-handling.html#key-modifiers)
Windows + , doesn't seem to respond, but that's likely due to the preexisting Windows shortcut.