### PR TITLE
Small fix for big issue - Fix spectrum

### DIFF
--- a/src/renderer/components/visualizers/SpectrumAnalyzer/SpectrumAnalyzer.vue
+++ b/src/renderer/components/visualizers/SpectrumAnalyzer/SpectrumAnalyzer.vue
@@ -50,7 +50,7 @@ onMounted(async () => {
   return vertices;
 };
 
-  const TOTAL_BARS = 1024;
+  const TOTAL_BARS = 1000;
 
   const loader = new THREE.FileLoader();
   const camera = new THREE.OrthographicCamera(0, width, -height * 1.25 , 0, 0, 10000 );

--- a/src/renderer/components/visualizers/SpectrumAnalyzer/SpectrumVertex.glsl
+++ b/src/renderer/components/visualizers/SpectrumAnalyzer/SpectrumVertex.glsl
@@ -1,7 +1,7 @@
 precision highp float;
 
 // All the amplitude levels for each frequency 1-22050hz
-uniform int u_amplitude[ 1024 ];
+uniform int u_amplitude[ 1000 ];
 uniform int u_height;
 
 // used to index the ampltude array for each bar instance


### PR DESCRIPTION
This should fix #287 and #327

changing line 4 of [SpectrumVertex.glsl](https://github.com/Geoxor/Amethyst/blob/master/src/renderer/components/visualizers/SpectrumAnalyzer/SpectrumVertex.glsl#L4) resolved this issue
`uniform int u_amplitude[ 1000 ];`
![image](https://github.com/Geoxor/Amethyst/assets/49094075/cb194353-f620-43bd-8ec6-d3962f68c995)
somehow 1008 works and 1009+ doesn't (it was originally 1024)

For some reason #200 is back and it forced me to play guess the number but i need to compile every number to check and result is 1008 works, 1009 doesn't work

![image](https://github.com/Geoxor/Amethyst/assets/49094075/924bdd5f-c89a-4b2d-974e-fdd440386184)
