### PR TITLE
player: macos requires absolute path for playback.

### DIFF
--- a/src/renderer/logic/player.ts
+++ b/src/renderer/logic/player.ts
@@ -5,6 +5,7 @@ import { ref } from "vue";
 import { AmethystAudioNodeManager } from "./audioManager";
 import { EventEmitter } from "./eventEmitter";
 import { secondsToColinHuman, secondsToHuman } from "@shared/formating";
+import { amethyst } from "@/amethyst";
 
 export enum LoopMode {
 	None,
@@ -52,7 +53,7 @@ export class Player extends EventEmitter<{
   }
 
   private setPlayingTrack(track: Track) {
-    this.input.src = track.path;
+    this.input.src = amethyst.getCurrentOperatingSystem() == 'mac' ? `file://${track.path}` : track.path;
     this.currentTrack.value = track;
     this.currentTrackIndex.value = this.queue.getList().indexOf(track);
     this.input.play();


### PR DESCRIPTION
This fixes audio playback on MacOS for once and all.

![image](https://github.com/Geoxor/Amethyst/assets/43046474/9e3c9307-7843-48da-bcc8-f7c7fd4bbc24)
