### PR TITLE
track: macos doesn't like fetch, use fs.readFile instead globally.

### DIFF
--- a/src/renderer/logic/track.ts
+++ b/src/renderer/logic/track.ts
@@ -48,7 +48,7 @@ export class Track {
   }
 
   private async fetchCache() {
-    return (await fetch(this.getCachePath())).json();
+    return (JSON.parse(await window.fs.readFile(this.getCachePath(true), 'utf-8')));
   }
 
   public async delete() {


### PR DESCRIPTION
This fixes issue with macOS not loading metadata properly due to improper path.

<img width="1680" alt="Screenshot 2024-02-08 at 12 35 39" src="https://github.com/Geoxor/Amethyst/assets/43046474/6a9e7aa9-1a4f-4ce9-8e0c-100646f322dd">
