### PR TITLE
electron: make menubar more native like on macos

### DIFF
--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -29,21 +29,54 @@ else {
 	app.whenReady()
 		.then(() => {
 
-			// Disables default zoom shortcuts because we remove the default menu actions
-			Menu.setApplicationMenu(Menu.buildFromTemplate([ {
-				label: "View",
-				submenu: [
-					{ role: "reload" },
-					{ role: "forceReload" },
-					{ role: "toggleDevTools" },
-					{ type: "separator" },
-					{ role: "resetZoom", enabled: true },
-					{ role: "zoomIn", enabled: false },
-					{ role: "zoomOut", enabled: false },
-					{ type: "separator" },
-					{ role: "togglefullscreen" },
-				],
-			},]));
+			if (process.platform === 'darwin') {
+				Menu.setApplicationMenu(Menu.buildFromTemplate([ 
+					{
+						label: app.name,
+						submenu: [
+							{ role: 'about' },
+							{ type: 'separator' },
+							{ role: 'services' },
+							{ type: 'separator' },
+							{ role: 'hide' },
+							{ role: 'hideOthers' },
+							{ role: 'unhide' },
+							{ type: 'separator' },
+							{ role: 'quit' }
+						  ],
+					},
+					{
+						label: "View",
+						submenu: [
+							{ role: "reload" },
+							{ role: "forceReload" },
+							{ role: "toggleDevTools" },
+							{ type: "separator" },
+							{ role: "resetZoom", enabled: true },
+							{ role: "zoomIn", enabled: false },
+							{ role: "zoomOut", enabled: false },
+							{ type: "separator" },
+							{ role: "togglefullscreen" },
+						],
+					}
+				]));
+			} else {
+				// Disables default zoom shortcuts because we remove the default menu actions
+				Menu.setApplicationMenu(Menu.buildFromTemplate([ {
+					label: "View",
+					submenu: [
+						{ role: "reload" },
+						{ role: "forceReload" },
+						{ role: "toggleDevTools" },
+						{ type: "separator" },
+						{ role: "resetZoom", enabled: true },
+						{ role: "zoomIn", enabled: false },
+						{ role: "zoomOut", enabled: false },
+						{ type: "separator" },
+						{ role: "togglefullscreen" },
+					],
+				},]));
+			}
 
 			const useVsync = store.get("useVsync", true);
 			if (useVsync) {


### PR DESCRIPTION
This makes the menu behave like it is supposed to on MacOS

Before:

![image](https://github.com/Geoxor/Amethyst/assets/43046474/3ecee090-964b-4d1b-82fc-47230e70b6df)

After:

![image](https://github.com/Geoxor/Amethyst/assets/43046474/85433b65-ed39-458e-b31c-64d6122d0675)
