### PR TITLE
Fix crash on initial launch when LocalStorage is not populated

### DIFF
--- a/src/renderer/amethyst.ts
+++ b/src/renderer/amethyst.ts
@@ -20,7 +20,7 @@ import { useLocalStorage } from "@vueuse/core";
 
 export const i18n = createI18n({
   fallbackLocale: "en-US", // set fallback locale
-  locale: JSON.parse(localStorage.getItem("settings")!).language,
+  locale: localStorage.getItem("settings") !== null ? JSON.parse(localStorage.getItem("settings")!).language : "en-US",
   messages,
 });
 


### PR DESCRIPTION
this PR fixes crash when the application tries to load settings from LocalStorage to get i18n language but it doesn't exist during initial load and just causes the application to crash.