### PR TITLE
fix CI by bumping node version to v20.0.0 from v18.0.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
           submodules: recursive
       - uses: actions/setup-node@v3
         with:
-          node-version: 18.0.0
+          node-version: 20.0.0
           cache: 'yarn'
 
       - name: Install gcc dependencies
@@ -61,7 +61,7 @@ jobs:
           submodules: recursive
       - uses: actions/setup-node@v3
         with:
-          node-version: 18.0.0
+          node-version: 20.0.0
           cache: 'yarn'
 
       - name: Install Dependencies
@@ -89,7 +89,7 @@ jobs:
   #         submodules: recursive
   #     - uses: actions/setup-node@v3
   #       with:
-  #         node-version: 18.0.0
+  #         node-version: 20.0.0
   #         cache: 'yarn'
 
   #     - name: Install Dependencies
@@ -122,7 +122,7 @@ jobs:
           submodules: recursive
       - uses: actions/setup-node@v3
         with:
-          node-version: 18.0.0
+          node-version: 20.0.0
           cache: 'yarn'
 
       - name: Install Dependencies
@@ -152,7 +152,7 @@ jobs:
           submodules: recursive
       - uses: actions/setup-node@v3
         with:
-          node-version: 18.0.0
+          node-version: 20.0.0
           cache: 'yarn'
 
       - name: Install linux dependencies


### PR DESCRIPTION
This actually makes the CI build artifacts again :)

NOTE: CI fails because it's trying to build it with the old CI...