### PR TITLE
Change workflow so forks don't try to release to aur

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -152,7 +152,7 @@ jobs:
     runs-on: ubuntu-latest
     # If we can't build, we should not release to AUR
     needs: [build-linux]
-    if: needs.build-linux.result == 'success' && github.ref == 'refs/heads/master'
+    if: needs.build-linux.result == 'success' && github.ref == 'refs/heads/master' && github.repository_owner == 'Geoxor'
     env:
       AUR_SSH_KEY: ${{ secrets.AUR_SSH_KEY }}
       COMMIT_LONGHASH: ${{ github.sha }}


### PR DESCRIPTION
Release to AUR -git action was only checking if commit was in main branch, so main branch of every master branch of every other fork also tried to run this job
![image](https://github.com/user-attachments/assets/d6199e22-e8ce-4641-9327-a1ab34996737)
