### PR TITLE
feat: macOS native menubar items

### DIFF
--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -6,7 +6,7 @@
  * When running `yarn build` or `yarn build:main`, this file is compiled to
  * `./src/main.js` using webpack. This gives us some performance wins.
  */
-import { Menu, app } from "electron";
+import {Menu, app, shell } from "electron";
 import { checkForUpdatesAndInstall, MainWindow } from "./mainWindow.js";
 import Store from "electron-store";
 import "./realtimeAudio.js";
@@ -33,12 +33,39 @@ else {
   app.whenReady()
     .then(() => {
 
+      const useVsync = store.get("useVsync", true);
+      if (useVsync) {
+        app.commandLine.removeSwitch("disable-frame-rate-limit");
+        console.log("Vsync enabled");
+      } else {
+        app.commandLine.appendSwitch("disable-frame-rate-limit");
+        console.log("Vsync disabled");
+      }
+
+      mainWindow = new MainWindow();
+
       if (process.platform === "darwin") {
-        Menu.setApplicationMenu(Menu.buildFromTemplate([ 
+        Menu.setApplicationMenu(Menu.buildFromTemplate([
           {
             label: app.name,
             submenu: [
               { role: "about" },
+              {
+                label: "Check for updates...",
+                toolTip: "",
+                click: async () => {
+                  mainWindow.window.webContents.send("check-for-updates");
+                }
+              },
+              { type: "separator" },
+              {
+                label: "Settings...",
+                toolTip: "",
+                accelerator: "Cmd+,",
+                click: async () => {
+                  mainWindow.window.webContents.send("open-settings-native");
+                }
+              },
               { type: "separator" },
               { role: "services" },
               { type: "separator" },
@@ -47,7 +74,49 @@ else {
               { role: "unhide" },
               { type: "separator" },
               { role: "quit" }
-              ],
+            ],
+          },
+          {
+            label: "File",
+            submenu: [
+              {
+                label: "Open file",
+                toolTip: "",
+                accelerator: "Cmd+O",
+                click: async () => {
+                  mainWindow.window.webContents.send("open-file-native");
+                }
+              },
+              {
+                label: "Open folder",
+                toolTip: "",
+                accelerator: "Cmd+Shift+O",
+                click: async () => {
+                  mainWindow.window.webContents.send("open-folder-native");
+                }
+              }
+            ],
+          },
+          {
+            label: "Queue",
+            submenu: [
+              {
+                label: "Clear queue",
+                toolTip: "",
+                accelerator: "Cmd+Shift+Z",
+                click: async () => {
+                  mainWindow.window.webContents.send("clear-queue-native");
+                }
+              },
+              {
+                label: "Reload queue",
+                toolTip: "",
+                accelerator: "Cmd+Alt+R",
+                click: async () => {
+                  mainWindow.window.webContents.send("reload-queue-native");
+                }
+              }
+            ],
           },
           {
             label: "View",
@@ -62,6 +131,35 @@ else {
               { type: "separator" },
               { role: "togglefullscreen" },
             ],
+          },
+          {
+            role: 'help',
+            submenu: [
+              {
+                label: 'Guides...',
+                click: async () => {
+                  await shell.openExternal("https://amethyst.geoxor.moe/guides/showcase")
+                }
+              },
+              {
+                label: 'User Manual...',
+                click: async () => {
+                  await shell.openExternal("https://amethyst.geoxor.moe/user-manual/keyboard-shortcuts")
+                }
+              },
+              {
+                label: 'Github Repository...',
+                click: async () => {
+                  await shell.openExternal("https://github.com/geoxor/amethyst")
+                }
+              },
+              {
+                label: 'Discord Server...',
+                click: async () => {
+                  await shell.openExternal("https://discord.gg/geoxor")
+                }
+              }
+            ]
           }
         ]));
       } else {
@@ -81,17 +179,6 @@ else {
           ],
         },]));
       }
-
-      const useVsync = store.get("useVsync", true);
-      if (useVsync) {
-        app.commandLine.removeSwitch("disable-frame-rate-limit");
-        console.log("Vsync enabled");
-      } else {
-        app.commandLine.appendSwitch("disable-frame-rate-limit");
-        console.log("Vsync disabled");
-      }
-
-       mainWindow = new MainWindow();
 
       app.on("window-all-closed", () => {
         // Respect the OSX convention of having the application in memory even

--- a/src/main/mainWindow.ts
+++ b/src/main/mainWindow.ts
@@ -119,6 +119,7 @@ export class MainWindow {
 		// and restore the maximized or full screen state
 
 		this.setIpcEvents();
+		this.setNativeMenuIpcEvents();
 		this.setWindowEvents();  
 	}
 
@@ -433,5 +434,15 @@ export class MainWindow {
 			}
 
 		}).forEach(([channel, handler]) => ipcMain.handle(channel, handler));
+	}
+
+	private setNativeMenuIpcEvents(): void {
+		Object.entries([
+			"open-settings-native",
+			"open-file-native",
+			"open-folder-native",
+			"clear-queue-native",
+			"reload-queue-native"
+		]).forEach(([channel]) => ipcMain.handle(channel, async () => {}));
 	}
 }

--- a/src/renderer/amethyst.ts
+++ b/src/renderer/amethyst.ts
@@ -264,7 +264,17 @@ export class Amethyst extends AmethystBackend {
       window.electron.ipcRenderer.on<string>("play-file", path => path !== "--require" && amethyst.player.queue.add(path).then(() => {
         amethyst.player.play(amethyst.player.queue.getList().findIndex(track => track.path == path));
       }));
+
       window.electron.ipcRenderer.on<(string)[]>("play-folder", paths => amethyst.player.queue.add(flattenArray(paths)));
+
+      // only register native menu listeners on macOS
+      if (this.getCurrentOperatingSystem() === "mac") {
+        window.electron.ipcRenderer.on("open-settings-native", () => router.push("/settings"));
+        window.electron.ipcRenderer.on("open-file-native", () => this.openAudioFilesAndAddToQueue());
+        window.electron.ipcRenderer.on("open-folder-native", () => this.openAudioFoldersAndAddToQueue());
+        window.electron.ipcRenderer.on("clear-queue-native", () => this.player.queue.clear());
+        window.electron.ipcRenderer.on("reload-queue-native", () => this.player.queue.fetchAsyncData(true));
+      }
   
       this.state.settings.behavior.fetchMetadataOnStartup && setTimeout(async() => {
         await this.player.queue.fetchAsyncData();

--- a/src/renderer/components/TopBar.vue
+++ b/src/renderer/components/TopBar.vue
@@ -57,8 +57,8 @@ provide("menuGroupRef", menuGroupRef);
 
 <template>
   <div
-    class=" z-100 font-main drag min-h-40px pr-2 text-12px select-none flex justify-between items-center transition-colors duration-user-defined"
-    :class="[amethyst.state.window.isFocused ? 'text-text-title' : 'text-text-subtitle']"
+    class=" z-100 font-main drag pr-2 text-12px select-none flex justify-between items-center transition-colors duration-user-defined"
+    :class="[amethyst.state.window.isFocused ? 'text-text-title' : 'text-text-subtitle', amethyst.getCurrentOperatingSystem() == 'mac' ? 'min-h-24px' : 'min-h-40px']"
   >
     <div
         v-if="amethyst.getCurrentOperatingSystem() !== 'mac'"

--- a/src/renderer/components/TopBar.vue
+++ b/src/renderer/components/TopBar.vue
@@ -61,9 +61,8 @@ provide("menuGroupRef", menuGroupRef);
     :class="[amethyst.state.window.isFocused ? 'text-text-title' : 'text-text-subtitle']"
   >
     <div
-      class="flex no-drag h-full items-center"
-    
-      :class="[amethyst.getCurrentOperatingSystem() == 'mac' && 'pl-16']"
+        v-if="amethyst.getCurrentOperatingSystem() !== 'mac'"
+        class="flex no-drag h-full items-center"
     >
       <div
         class="duration-user-defined logo w-52px h-full items-center flex justify-center cursor-heart-pointer rounded-br-8px hover:bg-primary/10 hover:text-primary"


### PR DESCRIPTION
Implements the native macOS bar for controls instead of inbuilt Amethyst menubar

## Image references

## About (app name)

<img width="291" alt="Screenshot 2025-05-14 at 2 02 10" src="https://github.com/user-attachments/assets/4912b015-53c9-4ebe-ba8a-ae76b7857816" />

## File

<img width="304" alt="Screenshot 2025-05-14 at 2 02 20" src="https://github.com/user-attachments/assets/17809f73-f72e-4402-9630-258b9dbc59f1" />

## Queue (previously Utility)

<img width="254" alt="Screenshot 2025-05-14 at 2 02 30" src="https://github.com/user-attachments/assets/8e8bf878-b7c4-4a7b-ab08-f81a064f43fe" />

## View

<img width="396" alt="Screenshot 2025-05-14 at 2 02 39" src="https://github.com/user-attachments/assets/41d05924-c60d-44af-a0d1-4b855b08356c" />

## Help (previously About)

<img width="596" alt="Screenshot 2025-05-14 at 2 02 47" src="https://github.com/user-attachments/assets/bf5fb312-ce2e-4482-b709-34dd646b802e" />

