### PR TITLE
Improve Discord RPC cover art lookup

### DIFF
--- a/src/renderer/logic/track.ts
+++ b/src/renderer/logic/track.ts
@@ -214,14 +214,16 @@ export class Track {
 
       // If missing artist or album, try parsing filename
       if (!artist || !album) {
-        const filename = this.path?.split(/[/\\]/).pop() || "";
-        const match = filename.match(/^(.+?)\s*-\s*(.+?)(?:\.[^.]+)?$/);
-        if (match) {
-          artist = artist || match[1].trim();
-          album = album || match[2].trim();
+        const fileWithExt = this.absolutePath?.split(/[/\\]/).pop() ?? "";
+        const fname = fileWithExt.replace(/\.[^/.]+$/, "");
+
+        if (fname.includes(" - ")) {
+          const [left, right] = fname.split(" - ");
+          artist ||= left.trim();
+          album ||= right.trim();
         }
-        else if (!album && filename) {
-          album = filename.replace(/\.[^.]+$/, "");
+        else {
+          album ||= fname;
         }
       }
 

--- a/src/renderer/logic/track.ts
+++ b/src/renderer/logic/track.ts
@@ -235,21 +235,17 @@ export class Track {
         query: queryString,
       });
 
-      if (!result.count)
-        return;
+      if (!result.count) return;
 
       const [topResult] = result.releases;
       muid = topResult.id;
     }
 
     try {
-      const response = await (await fetch(`https://coverartarchive.org/release/${muid}/front-500`));
-      if (response.ok)
-        this.coverUrl = response.url;
+      const response = await fetch(`https://coverartarchive.org/release/${muid}/front-500`);
+      if (response.ok) this.coverUrl = response.url;
     }
-    catch (error) {
-      console.log("Error fetching cover art:", error);
-    }
+    catch {}
   };
 
   /**


### PR DESCRIPTION
Fixes #854

Might be a little over-engineered. 
First time working with Typescript, apologies if I'm not aware of good coding practices.

I've tested this to work with random music files I've had lying around, the patch consistently providing better results than the existing code, even in cases with no metadata tags to work off of.
I haven't manually tested whether the path splitting pattern works correctly on Unix systems, but I'm pretty confident it should.

cc @Nyabsi as the author of the original code, to double-check if I missed any edge cases the original code covered.