### PR TITLE
Move importing realtime audio to after the main instance starts

### DIFF
--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -6,7 +6,6 @@
  * When running `yarn build` or `yarn build:main`, this file is compiled to
  * `./src/main.js` using webpack. This gives us some performance wins.
  */
-import "./realtimeAudio.js";
 import "./drag-drop.js";
 
 import { app, Menu, shell } from "electron";
@@ -33,7 +32,9 @@ if (!app.requestSingleInstanceLock()) {
 }
 else {
   app.whenReady()
-    .then(() => {
+    .then(async () => {
+      await import("./realtimeAudio.js");
+
       const useVsync = store.get("useVsync", true);
       if (useVsync) {
         app.commandLine.removeSwitch("disable-frame-rate-limit");


### PR DESCRIPTION
Since Amethyst's realtime audio library (audify) attempts to touch ASIO (present or not), it temporarily disconnects other programs interacting with the audio hardware (because of ASIO's exclusive mode). This is problematic because some programs, like Ableton Live, won't refresh after disconnection, thus their audio engine is destroyed until the user manually fixes it, and it gets really annoying when you try to open a file on Amethyst, and that new instance already initializes before checking if another instance is already present and exit.

A workaround for this is to move the realtime audio code import to after the app is ready, until audify has a way to not attempt to initiate ASIO blindly.