### PR TITLE
feat: add view refreshing when double clicking nav buttons

### DIFF
--- a/src/renderer/components/NavigationButton.vue
+++ b/src/renderer/components/NavigationButton.vue
@@ -21,6 +21,7 @@ const router = useRouter();
       mobile && 'w-full',
     ]"
   >
+    <!-- TODO: support mobile view refreshing -->
     <button
       :class="[
         isActive && 'active',
@@ -31,6 +32,7 @@ const router = useRouter();
       class="duration-user-defined items-center gap-2 transition-colors duration-user-defined flex relative disable-select no-drag"
       @touchstart="router.push({ name: routeName })"
       @mousedown="router.push({ name: routeName })"
+      @dblclick="amethyst.state.emit('view:refresh', '')"
     >
       <icon
         v-if="icon"

--- a/src/renderer/state.ts
+++ b/src/renderer/state.ts
@@ -50,6 +50,7 @@ export interface IContextMenuOption {
 
 export interface StateEvents {
   "theme:change": string;
+  "view:refresh": string;
 }
 
 export class State extends EventEmitter<StateEvents> {

--- a/src/renderer/views/FavoritesView.vue
+++ b/src/renderer/views/FavoritesView.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { useLocalStorage } from "@vueuse/core";
-import { computed, onMounted } from "vue";
+import { computed, onMounted, onUnmounted } from "vue";
 
 import { amethyst } from "@/amethyst.js";
 import TrackCard from "@/components/TrackCard.vue";
@@ -11,6 +11,14 @@ onMounted(() => {
 });
 
 const filterText = useLocalStorage("filterTextFavorites", "");
+const clearFilterText = () => filterText.value = "";
+
+onMounted(() => {
+  amethyst.state.on("view:refresh", clearFilterText);
+});
+onUnmounted(() => {
+  amethyst.state.off("view:refresh", clearFilterText);
+});
 </script>
 
 <template>

--- a/src/renderer/views/QueueView.vue
+++ b/src/renderer/views/QueueView.vue
@@ -21,12 +21,16 @@ const scrollToCurrentElement = (track?: Track) => {
 };
 
 const autoscroll = () => amethyst.state.followQueue.value && scrollToCurrentElement();
+const clearFilterText = () => filterText.value = "";
+
 watch(() => amethyst.state.followQueue.value, () => autoscroll());
 onMounted(() => {
   amethyst.player.on("player:trackChange", autoscroll);
+  amethyst.state.on("view:refresh", clearFilterText);
 });
 onUnmounted(() => {
   amethyst.player.off("player:trackChange", autoscroll);
+  amethyst.state.on("view:refresh", clearFilterText);
 });
 </script>
 


### PR DESCRIPTION
This PR adds a new small feature to the renderer. You can now double-click the navigation buttons to "refresh" the view.
This will fire a new state event, which FavoritesView and QueueView listen to. They will then clear their search boxes in response.

I found myself using this gesture quite often, and I thought it would be convenient.
Let me know if I should move the event to another EventEmitter or if you want the trigger to be something else.
This has no mobile support yet, as it would entail manually checking for a double tap.
