### PR TITLE
fix: load song metadata on drag and drop

### DIFF
--- a/src/renderer/amethyst.ts
+++ b/src/renderer/amethyst.ts
@@ -589,9 +589,9 @@ export class Amethyst extends AmethystBackend {
           this.isLoading.value = false;
           return console.error(error, "Dropped path is not a folder");
         };
-
-        await amethyst.player.queue.fetchAsyncData();
       }
+
+      await amethyst.player.queue.fetchAsyncData();
       this.isLoading.value = false;
     });
 


### PR DESCRIPTION
I saw the issue created for this bug while just clicking around in the repo.
The fix ended up being to move one line down so it's always run before returning from the drag and drop handler.
Using `fetchAsyncData` on the whole queue is okay performance-wise because it is idempotent and that was already how it was done when you dropped a whole folder into the program.

Fixes #821
