### PR TITLE
fix: fix sorting by track number

### DIFF
--- a/src/renderer/logic/queue.ts
+++ b/src/renderer/logic/queue.ts
@@ -13,6 +13,8 @@ const COMPARATORS_BY_METHOD = {
   trackNumber: (a, b) => {
     const diskNumberDiff = (a.getDiskNumber() ?? 1) - (b.getDiskNumber() ?? 1);
     if (diskNumberDiff !== 0) return diskNumberDiff;
+	// delegate to copy of album comparator if the two tracks are not in the same album
+    if (a.getAlbum() !== b.getAlbum()) return (a.getAlbum() || "") > (b.getAlbum() || "") ? 1 : -1;
     return (a.getTrackNumber() ?? 1) - (b.getTrackNumber() ?? 1);
   },
   diskNumber: (a, b) => (a.getDiskNumber() ?? 1) > (b.getDiskNumber() ?? 1) ? 1 : -1,


### PR DESCRIPTION
Makes sorting by track number actually useful by sorting by album first and then track number.
Fixes #858.
