### PR TITLE
fix: increase bottom padding of inspectors

### DIFF
--- a/src/renderer/components/Inspector/NodeInspector.vue
+++ b/src/renderer/components/Inspector/NodeInspector.vue
@@ -12,7 +12,7 @@ import DropdownInput from "../v2/DropdownInput.vue";
 </script>
 
 <template>
-  <div class="pb-32 h-full overflow-y-auto">
+  <div class="pb-42 h-full overflow-y-auto">
     <section controls>
       <h1>
         <icon

--- a/src/renderer/components/Inspector/TrackInspector.vue
+++ b/src/renderer/components/Inspector/TrackInspector.vue
@@ -25,7 +25,7 @@ function cloneWithoutPicture(obj: Record<string, any>): Record<string, any> {
 </script>
 
 <template>
-  <div class="pb-32 h-full overflow-y-auto">
+  <div class="pb-42 h-full overflow-y-auto">
     <inspector-section title="track.covers" icon="ic:twotone-image">
       <!-- FIXME: Cover art data will sometimes not show, even though metadata is loaded https://files.catbox.moe/jusams.png -->
       <div


### PR DESCRIPTION
Increases the bottom padding of both the track inspector and the node inspector. This provides more space that you can scroll past to show the inspector items that would be otherwise be covered by the playback controls.

Fixes #884.
