### PR TITLE
fix: use absolute path when opening cache file in explorer

### DIFF
--- a/src/renderer/components/Inspector/TrackInspector.vue
+++ b/src/renderer/components/Inspector/TrackInspector.vue
@@ -111,7 +111,7 @@ function cloneWithoutPicture(obj: Record<string, any>): Record<string, any> {
       <inspector-button
         name="track.show_amf_in_file_explorer"
         icon="ic:twotone-open-in-new"
-        @click="amethyst.showItem(track.getCachePath())"
+        @click="amethyst.showItem(track.getCachePath(true))"
       />
     </inspector-section>
   </div>


### PR DESCRIPTION
This PR makes the `open .amf in explorer` button pass the absolute path to `amethyst.showItem()` instead of the default `file://`-prefixed path.


> [!WARNING]
> This may break the feature on Windows. I have not tested it on a Windows machine as I do not have access to one.

Fixes #896.