### PR TITLE
chore: optimize queue search

### DIFF
--- a/src/renderer/logic/queue.ts
+++ b/src/renderer/logic/queue.ts
@@ -44,6 +44,8 @@ export type PossibleSortingMethods = keyof typeof COMPARATORS_BY_METHOD;
 export class Queue {
   private savedQueue = useLocalStorage<string[]>("queuev2", []);
   private list: Ref<Map<string, Track>> = ref(new Map());
+  private lastSearch = "";
+  private lastSearchList: Track[] = [];
 
   public totalSize = ref(0);
   public totalDuration = ref(0);
@@ -61,22 +63,11 @@ export class Queue {
   }
 
   public search(search: string) {
-    const words = search.split(" ");
-    let results = this.getList();
-
-    for (let i = 0; i < words.length; i++) {
-      const word = words[i].toLowerCase();
-      results = results
-        .filter((track) => word ? !track.hasErrored : track)
-        .filter((track) =>
-          track.getFilename().toLowerCase().includes(word)
-          || track.getArtistsFormatted()?.toLowerCase().includes(word)
-          || track.getTitle()?.toLowerCase().includes(word)
-          || track.getGenreFormatted()?.toLowerCase().includes(word)
-          || track.getAlbum()?.toLowerCase().includes(word));
-    }
-
-    return results;
+    const list = search.includes(this.lastSearch) ? this.lastSearchList : this.getList();
+    const searchedTracks = this.searchTracks(search, list);
+    this.lastSearchList = searchedTracks;
+    this.lastSearch = search;
+    return searchedTracks;
   }
 
   public searchTracks(search: string, tracks: Track[]) {


### PR DESCRIPTION
This PR optimizes by searching in the results from the previous search if the current query contains the previous one. I.e., it searches inside the search results if the new query is more specific than the last one.
This should speed up searching a bit when a lot of tracks are loaded because Amethyst searches on every key press. The lag spikes are probably caused by creating the list items though. 
This PR also consolidates the two duplicated implementations of searching in `Queue#search` and `Queue#searchTracks` as per the DRY principle.


However, there is a small side effect: tracks that have their metadata fetched in between search precisions won't be included.
Let me know if you want me to fix that by including all tracks whose metadata has been newly fetched in every search precision. 
