### PR TITLE
chore: bump minimal-discord-rpc to 1.0.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -364,7 +364,7 @@
     "@floating-ui/dom": "^1.2.7",
     "@iconify/vue": "^5.0.0",
     "@intlify/unplugin-vue-i18n": "^1.6.0",
-    "@nyabsi/minimal-discord-rpc": "^1.0.1",
+    "@nyabsi/minimal-discord-rpc": "^1.0.2",
     "@supercharge/promise-pool": "^2.4.0",
     "@types/node-wav": "^0.0.4",
     "@vue-flow/additional-components": "^1.3.3",


### PR DESCRIPTION
bumps https://www.npmjs.com/package/@nyabsi/minimal-discord-rpc from 1.0.1 to 1.0.2 which contains changes made in PR by @N1kO23 at https://github.com/Nyabsi/minimal-discord-rpc/pull/1